### PR TITLE
HPLProfileView support dynamic init and loaded in another xib

### DIFF
--- a/ReusableViewExperiment/HPLProfileView.m
+++ b/ReusableViewExperiment/HPLProfileView.m
@@ -30,11 +30,30 @@
 }
 
 #pragma mark - Custom loading
-
+/*
 - (void)awakeFromNib {
     [super awakeFromNib];
 
     [self addInsideView];
+}
+*/
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder
+{
+    self = [super initWithCoder:aDecoder];
+    if (self) {
+        [self addInsideView];
+    }
+    return self;
+}
+
+- (instancetype)initWithFrame:(CGRect)frame
+{
+    self = [super initWithFrame:frame];
+    if (self) {
+        [self addInsideView];
+    }
+    return self;
 }
 
 - (void)addInsideView {

--- a/ReusableViewExperiment/ViewController.m
+++ b/ReusableViewExperiment/ViewController.m
@@ -30,6 +30,11 @@
     [self.profileViews enumerateObjectsUsingBlock:^(HPLProfileView *profileView, NSUInteger idx, BOOL * _Nonnull stop) {
         profileView.person = people[idx];
     }];
+
+    // dynamic
+    HPLProfileView *dynamicView = [[HPLProfileView alloc] initWithFrame:CGRectMake(0, 20, 70, 50)];
+    dynamicView.person = [[HPLPerson alloc] initWithFirstName:@"Chris" lastName:@"Lattner"];
+    [self.view addSubview:dynamicView];
 }
 
 @end


### PR DESCRIPTION
如果 `HPLProfileView` 要能夠同時支援 `initWithFrame` 跟 loaded inside another xib，
也許 `addInsideView` 放在 `initWithCoder` 跟 `initWithFrame` 比較適合?
